### PR TITLE
Hide password form until needed

### DIFF
--- a/packages/client/src/components/dashboard/Dashboard.tsx
+++ b/packages/client/src/components/dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, MouseEvent } from 'react';
+import React, { useState, MouseEvent, useEffect } from 'react';
 import { styled } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import MuiDrawer from '@mui/material/Drawer';
@@ -21,7 +21,7 @@ import Avatar from '@mui/material/Avatar';
 import { mainListItems } from './listItems';
 import { pageRoutes } from '../../routes';
 import { useGetPing } from '../../api/ping';
-import { isAuthError } from '../../utils/api';
+import { isAuthError, getIsPasswordlessLogin } from '../../utils/api';
 import { ReactComponent as Logo } from '../../assets/images/logo.svg';
 
 const drawerWidth: number = 240;
@@ -76,6 +76,7 @@ const Drawer = styled(MuiDrawer, { shouldForwardProp: (prop) => prop !== 'open' 
 
 export default function Dashboard() {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [isPasswordlessLogin, setIsPasswordlessLogin] = useState(true);
   const toggleDrawer = () => {
     setIsDrawerOpen(!isDrawerOpen);
   };
@@ -90,6 +91,10 @@ export default function Dashboard() {
   };
 
   const ping = useGetPing();
+
+  useEffect(() => {
+    setIsPasswordlessLogin(getIsPasswordlessLogin());
+  }, []);
 
   if (ping.isLoading || isAuthError(ping.error)) {
     return (
@@ -157,8 +162,14 @@ export default function Dashboard() {
               'aria-labelledby': 'basic-button',
             }}
           >
-            <MenuItem component={Link} to={pageRoutes.logout}>Logout</MenuItem>
-            <MenuItem component={Link} to={pageRoutes.changePassword}>Change Password</MenuItem>
+            {
+              !isPasswordlessLogin && (
+                <MenuItem component={Link} to={pageRoutes.logout}>Logout</MenuItem>
+              )
+            }
+            <MenuItem component={Link} to={pageRoutes.changePassword}>
+              Change Password
+            </MenuItem>
           </Menu>
         </Toolbar>
       </AppBar>

--- a/packages/client/src/components/login/Login.tsx
+++ b/packages/client/src/components/login/Login.tsx
@@ -5,6 +5,7 @@ import TextField from '@mui/material/TextField';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Container from '@mui/material/Container';
+import CircularProgressIcon from '@mui/material/CircularProgress';
 import { useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 
@@ -20,18 +21,24 @@ export default function Login() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [isFormDisabled, setIsFormDisabled] = useState(false);
+  const [showPasswordForm, setShowPasswordForm] = useState(false);
+  const [showBackendErrorMessage, setShowBackendErrorMessage] = useState(false);
   const tryPasswordlessLogin = async () => {
     try {
       const response = await api.post<PasswordlessLoginResponse>(
         apiRoutes.authTryPasswordlessLogin, {},
       );
+      setShowBackendErrorMessage(false);
       if (!response.ok) {
+        setShowPasswordForm(true);
         return;
       }
+      setShowPasswordForm(false);
       saveAuthTokens(response);
       queryClient.invalidateQueries();
       navigate(pageRoutes.home, { replace: true });
     } catch (error) {
+      setShowBackendErrorMessage(true);
       errorToast(
         ((error instanceof HttpError) && error.message) || 'Internal error',
       );
@@ -76,28 +83,45 @@ export default function Login() {
         <Typography component="h1" variant="h5">
           Log In
         </Typography>
-        <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
-          <TextField
-            margin="normal"
-            required
-            fullWidth
-            name="password"
-            label="Password"
-            type="password"
-            id="password"
-            autoComplete="current-password"
-            disabled={isFormDisabled}
-          />
-          <Button
-            type="submit"
-            fullWidth
-            variant="contained"
-            sx={{ mt: 3, mb: 2 }}
-            disabled={isFormDisabled}
-          >
-            Log In
-          </Button>
-        </Box>
+        {
+          !showPasswordForm && !showBackendErrorMessage && (
+            <CircularProgressIcon sx={{ margin: 'auto', mt: 3 }} />
+          )
+        }
+        {
+          showPasswordForm && (
+            <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
+              <TextField
+                margin="normal"
+                required
+                fullWidth
+                name="password"
+                label="Password"
+                type="password"
+                id="password"
+                autoComplete="current-password"
+                disabled={isFormDisabled}
+              />
+              <Button
+                type="submit"
+                fullWidth
+                variant="contained"
+                sx={{ mt: 3, mb: 2 }}
+                disabled={isFormDisabled}
+              >
+                Log In
+              </Button>
+            </Box>
+          )
+        }
+        {
+          showBackendErrorMessage && (
+            <Typography component="p" color="error" sx={{ mt: 1 }}>
+              Bad response from backend.
+              Please try reloading the page, and if the problem persists reboot the server.
+            </Typography>
+          )
+        }
       </Box>
       <Copyright />
     </Container>

--- a/packages/client/src/components/login/Login.tsx
+++ b/packages/client/src/components/login/Login.tsx
@@ -11,6 +11,7 @@ import { useNavigate } from 'react-router-dom';
 
 import {
   api, AuthTokensResponse, HttpError, PasswordlessLoginResponse, saveAuthTokens,
+  saveIsPasswordlessLogin,
 } from '../../utils/api';
 import { apiRoutes, pageRoutes } from '../../routes';
 import { errorToast } from '../../utils/toast';
@@ -34,6 +35,7 @@ export default function Login() {
         return;
       }
       setShowPasswordForm(false);
+      saveIsPasswordlessLogin(true);
       saveAuthTokens(response);
       queryClient.invalidateQueries();
       navigate(pageRoutes.home, { replace: true });
@@ -55,6 +57,7 @@ export default function Login() {
       const response = await api.post<AuthTokensResponse>(apiRoutes.authLogin, {
         password: data.get('password'),
       });
+      saveIsPasswordlessLogin(false);
       saveAuthTokens(response);
       queryClient.invalidateQueries();
       navigate(pageRoutes.home, { replace: true });

--- a/packages/client/src/utils/api.ts
+++ b/packages/client/src/utils/api.ts
@@ -29,8 +29,16 @@ export function saveAuthTokens({
   window.sessionStorage.setItem('authTokenExpiresAt', authTokenExpiresAt.toJSON());
 }
 
+export function saveIsPasswordlessLogin(value: boolean): void {
+  window.sessionStorage.setItem('isPasswordlessLogin', value ? 'true' : 'false');
+}
+
+export function getIsPasswordlessLogin(): boolean {
+  return window.sessionStorage.getItem('isPasswordlessLogin') === 'true';
+}
+
 export function deleteAuthTokens() {
-  for (const item of ['authToken', 'authTokenExpiresAt', 'refreshToken']) {
+  for (const item of ['authToken', 'authTokenExpiresAt', 'refreshToken', 'isPasswordlessLogin']) {
     window.sessionStorage.removeItem(item);
   }
 }


### PR DESCRIPTION
Hide irrelevant password form and logout form when they are not needed.

When password is set to empty-string then passwordless-login logic is used.

Closing #10 