### PR TITLE
Use reply text for missing parameters

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -33,6 +33,7 @@ export enum BotCommandName {
 interface BotCommand {
   command: BotCommandName;
   description: string;
+  parametersRequestMessage?: string;
 }
 
 export const telegramCommands: BotCommand[] = [
@@ -70,10 +71,22 @@ export const telegramCommands: BotCommand[] = [
       'Get notifications when a transaction is found in the mempool, confirmed,',
       'or is being double-spent.',
     ].join(' '),
+    parametersRequestMessage: [
+      'Which transaction-id do you want to watch? You can specify only the id like:',
+      '"a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",',
+      'or you can add a nickname like:',
+      '"pizza_order:a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d".',
+      'The nickname should not contain spaces.',
+    ].join(' '),
   },
   {
     command: BotCommandName.UnwatchTransactions,
     description: 'Stop getting notifications about one or more transactions.',
+    parametersRequestMessage: [
+      'Which transaction-ids or nicknames of the transactions do you no longer want',
+      'to watch? You can specify multiple values with spaces between them.',
+      'You can also specify only the prefix, with a "*" at the end, like: "a1075db55d416d3c*".',
+    ].join(' '),
   },
   {
     command: BotCommandName.WatchAddresses,
@@ -82,14 +95,27 @@ export const telegramCommands: BotCommand[] = [
       'mempool or confirmed. Get notification when a transaction spending from the given',
       'addresses is confirmed (but not when it is only added to the mempool).',
     ].join(' '),
+    parametersRequestMessage: [
+      'Which addresses do you want to watch? You can specify only the address, like:',
+      '"17SkEw2md5avVNyYgj6RiXuQKNwkXaxFyQ", or you can add a nickname like:',
+      '"pizza_guy:17SkEw2md5avVNyYgj6RiXuQKNwkXaxFyQ".',
+      'You can specify multiple values with spaces between them.',
+      'The nicknames should not contain spaces.',
+    ].join(' '),
   },
   {
     command: BotCommandName.UnwatchAddresses,
     description: 'Stop getting notifications about one or more addresses.',
+    parametersRequestMessage: [
+      'Which addresses or nicknames of addresses do you no longer want to watch?',
+      'You can specify multiple values with spaces between them.',
+      'You can also specify only the prefix, with a "*" at the end, like: "17SkEw2m*".',
+    ].join(' '),
   },
   {
     command: BotCommandName.WatchPriceChange,
     description: 'Watch changes in the price of Bitcoin (in USD).',
+    parametersRequestMessage: 'What price change (in USD) do you want to watch?',
   },
   {
     command: BotCommandName.UnwatchPriceChange,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -18,16 +18,10 @@ export enum BotCommandName {
   Quit = 'quit',
   WatchTransaction = 'watchtransaction',
   UnwatchTransactions = 'unwatchtransactions',
-  Wtx = 'wtx',
-  Uwtxs = 'uwtxs',
   WatchAddresses = 'watchaddresses',
   UnwatchAddresses = 'unwatchaddresses',
-  Wads = 'wads',
-  Uwads = 'uwads',
   WatchPriceChange = 'watchpricechange',
   UnwatchPriceChange = 'unwatchpricechange',
-  Wpc = 'wpc',
-  Uwpc = 'uwpc',
   WatchNewBlocks = 'watchnewblocks',
   UnwatchNewBlocks = 'unwatchnewblocks',
   WatchMempoolClear = 'watchmempoolclear',
@@ -78,16 +72,8 @@ export const telegramCommands: BotCommand[] = [
     ].join(' '),
   },
   {
-    command: BotCommandName.Wtx,
-    description: `Short for /${BotCommandName.WatchTransaction}.`,
-  },
-  {
     command: BotCommandName.UnwatchTransactions,
     description: 'Stop getting notifications about one or more transactions.',
-  },
-  {
-    command: BotCommandName.Uwtxs,
-    description: `Short for /${BotCommandName.UnwatchTransactions}.`,
   },
   {
     command: BotCommandName.WatchAddresses,
@@ -98,32 +84,16 @@ export const telegramCommands: BotCommand[] = [
     ].join(' '),
   },
   {
-    command: BotCommandName.Wads,
-    description: `Short for /${BotCommandName.WatchAddresses}.`,
-  },
-  {
     command: BotCommandName.UnwatchAddresses,
     description: 'Stop getting notifications about one or more addresses.',
-  },
-  {
-    command: BotCommandName.Uwads,
-    description: `Short for /${BotCommandName.UnwatchAddresses}.`,
   },
   {
     command: BotCommandName.WatchPriceChange,
     description: 'Watch changes in the price of Bitcoin (in USD).',
   },
   {
-    command: BotCommandName.Wpc,
-    description: `Short for /${BotCommandName.WatchPriceChange}.`,
-  },
-  {
     command: BotCommandName.UnwatchPriceChange,
     description: 'Stop getting notifications about changes in the price of Bitcoin.',
-  },
-  {
-    command: BotCommandName.Uwpc,
-    description: `Short for /${BotCommandName.UnwatchPriceChange}.`,
   },
   {
     command: BotCommandName.WatchMempoolClear,

--- a/packages/server/src/helpers/telegram.ts
+++ b/packages/server/src/helpers/telegram.ts
@@ -822,10 +822,11 @@ export class TelegrafManager {
                 user.telegramUsername = ctx.from.username;
               }
             }
+            const args = ctx.message.text.split(/\s+/).slice(1);
             if (this[command]) {
-              await this[command](ctx, user);
+              await this[command](ctx, user, args);
             } else {
-              await TelegrafManager[command](ctx, user);
+              await TelegrafManager[command](ctx, user, args);
             }
           } catch (error) {
             logger.error(
@@ -972,9 +973,9 @@ export class TelegrafManager {
     ctx.replyWithMarkdownV2(escapeMarkdown('Stopped watching new blocks.'));
   }
 
-  async [BotCommandName.WatchTransaction](ctx: TextContext, user: UserDocument) {
-    const [commandName, ...args] = ctx.message.text.split(/\s+/);
+  async [BotCommandName.WatchTransaction](ctx: TextContext, user: UserDocument, args: string[]) {
     if (args.length === 0) {
+      const [commandName] = ctx.message.text.split(/\s+/);
       ctx.replyWithMarkdownV2(escapeMarkdown([
         `Syntax: "${commandName} <transaction-id>" or "${
           commandName
@@ -1143,13 +1144,17 @@ export class TelegrafManager {
     }
   }
 
-  async [BotCommandName.Wtx](ctx: TextContext, user: UserDocument) {
-    return this[BotCommandName.WatchTransaction](ctx, user);
+  async [BotCommandName.Wtx](ctx: TextContext, user: UserDocument, args: string[]) {
+    return this[BotCommandName.WatchTransaction](ctx, user, args);
   }
 
-  static async [BotCommandName.UnwatchTransactions](ctx: TextContext, user: UserDocument) {
-    const [commandName, ...args] = ctx.message.text.split(/\s+/);
+  static async [BotCommandName.UnwatchTransactions](
+    ctx: TextContext,
+    user: UserDocument,
+    args: string[],
+  ) {
     if (args.length === 0) {
+      const [commandName] = ctx.message.text.split(/\s+/);
       ctx.replyWithMarkdownV2(escapeMarkdown(
         `Syntax: "${commandName} <transaction-id-in-lowercase>" or "${
           commandName
@@ -1201,13 +1206,17 @@ export class TelegrafManager {
     ));
   }
 
-  static async [BotCommandName.Uwtxs](ctx: TextContext, user: UserDocument) {
-    return TelegrafManager[BotCommandName.UnwatchTransactions](ctx, user);
+  static async [BotCommandName.Uwtxs](ctx: TextContext, user: UserDocument, args: string[]) {
+    return TelegrafManager[BotCommandName.UnwatchTransactions](ctx, user, args);
   }
 
-  static async [BotCommandName.WatchAddresses](ctx: TextContext, user: UserDocument) {
-    const [commandName, ...args] = ctx.message.text.split(/\s+/);
+  static async [BotCommandName.WatchAddresses](
+    ctx: TextContext,
+    user: UserDocument,
+    args: string[],
+  ) {
     if (args.length === 0) {
+      const [commandName] = ctx.message.text.split(/\s+/);
       ctx.replyWithMarkdownV2(escapeMarkdown([
         `Syntax: "${commandName} <address1> <address2> ..." or "${
           commandName
@@ -1297,13 +1306,17 @@ export class TelegrafManager {
     ].join(' ')));
   }
 
-  static async [BotCommandName.Wads](ctx: TextContext, user: UserDocument) {
-    return TelegrafManager[BotCommandName.WatchAddresses](ctx, user);
+  static async [BotCommandName.Wads](ctx: TextContext, user: UserDocument, args: string[]) {
+    return TelegrafManager[BotCommandName.WatchAddresses](ctx, user, args);
   }
 
-  static async [BotCommandName.UnwatchAddresses](ctx: TextContext, user: UserDocument) {
-    const [commandName, ...args] = ctx.message.text.split(/\s+/);
+  static async [BotCommandName.UnwatchAddresses](
+    ctx: TextContext,
+    user: UserDocument,
+    args: string[],
+  ) {
     if (args.length === 0) {
+      const [commandName] = ctx.message.text.split(/\s+/);
       ctx.replyWithMarkdownV2(escapeMarkdown(
         `Syntax: "${commandName} <address>" or "${
           commandName
@@ -1355,13 +1368,17 @@ export class TelegrafManager {
     ));
   }
 
-  static async [BotCommandName.Uwads](ctx: TextContext, user: UserDocument) {
-    return TelegrafManager[BotCommandName.UnwatchAddresses](ctx, user);
+  static async [BotCommandName.Uwads](ctx: TextContext, user: UserDocument, args: string[]) {
+    return TelegrafManager[BotCommandName.UnwatchAddresses](ctx, user, args);
   }
 
-  static async [BotCommandName.WatchPriceChange](ctx: TextContext, user: UserDocument) {
-    const [commandName, ...args] = ctx.message.text.split(/\s+/);
+  static async [BotCommandName.WatchPriceChange](
+    ctx: TextContext,
+    user: UserDocument,
+    args: string[],
+  ) {
     if ((args.length === 0) || (args.length > 1)) {
+      const [commandName] = ctx.message.text.split(/\s+/);
       ctx.replyWithMarkdownV2(escapeMarkdown([
         `Syntax: "${commandName} <price-delta-in-usd>"`,
         `i.e. To get a notification when the price changes by $1000, use "${commandName} 1000".`,
@@ -1404,8 +1421,8 @@ export class TelegrafManager {
     }
   }
 
-  static async [BotCommandName.Wpc](ctx: TextContext, user: UserDocument) {
-    return TelegrafManager[BotCommandName.WatchPriceChange](ctx, user);
+  static async [BotCommandName.Wpc](ctx: TextContext, user: UserDocument, args: string[]) {
+    return TelegrafManager[BotCommandName.WatchPriceChange](ctx, user, args);
   }
 
   static async [BotCommandName.UnwatchPriceChange](ctx: TextContext, user: UserDocument) {

--- a/packages/server/src/helpers/telegram.ts
+++ b/packages/server/src/helpers/telegram.ts
@@ -877,7 +877,9 @@ export class TelegrafManager {
       await bot.launch({
         dropPendingUpdates: true,
       });
-      await bot.telegram.setMyCommands(telegramCommands);
+      await bot.telegram.setMyCommands(
+        telegramCommands.map(({ command, description }) => ({ command, description })),
+      );
       this.internalBot = bot;
       this.internalStatus = TelegramStatus.Running;
     } catch (error) {

--- a/packages/server/src/helpers/telegram.ts
+++ b/packages/server/src/helpers/telegram.ts
@@ -1144,10 +1144,6 @@ export class TelegrafManager {
     }
   }
 
-  async [BotCommandName.Wtx](ctx: TextContext, user: UserDocument, args: string[]) {
-    return this[BotCommandName.WatchTransaction](ctx, user, args);
-  }
-
   static async [BotCommandName.UnwatchTransactions](
     ctx: TextContext,
     user: UserDocument,
@@ -1204,10 +1200,6 @@ export class TelegrafManager {
         (deleteResult.deletedCount === 1) ? 'transaction-watch was' : 'transaction-watches were'
       } removed.`,
     ));
-  }
-
-  static async [BotCommandName.Uwtxs](ctx: TextContext, user: UserDocument, args: string[]) {
-    return TelegrafManager[BotCommandName.UnwatchTransactions](ctx, user, args);
   }
 
   static async [BotCommandName.WatchAddresses](
@@ -1306,10 +1298,6 @@ export class TelegrafManager {
     ].join(' ')));
   }
 
-  static async [BotCommandName.Wads](ctx: TextContext, user: UserDocument, args: string[]) {
-    return TelegrafManager[BotCommandName.WatchAddresses](ctx, user, args);
-  }
-
   static async [BotCommandName.UnwatchAddresses](
     ctx: TextContext,
     user: UserDocument,
@@ -1368,10 +1356,6 @@ export class TelegrafManager {
     ));
   }
 
-  static async [BotCommandName.Uwads](ctx: TextContext, user: UserDocument, args: string[]) {
-    return TelegrafManager[BotCommandName.UnwatchAddresses](ctx, user, args);
-  }
-
   static async [BotCommandName.WatchPriceChange](
     ctx: TextContext,
     user: UserDocument,
@@ -1421,10 +1405,6 @@ export class TelegrafManager {
     }
   }
 
-  static async [BotCommandName.Wpc](ctx: TextContext, user: UserDocument, args: string[]) {
-    return TelegrafManager[BotCommandName.WatchPriceChange](ctx, user, args);
-  }
-
   static async [BotCommandName.UnwatchPriceChange](ctx: TextContext, user: UserDocument) {
     await UsersModel.updateOne(
       {
@@ -1442,10 +1422,6 @@ export class TelegrafManager {
     if (user.watchPriceChange) {
       priceWatcher.unwatchPriceChange(user._id.toString());
     }
-  }
-
-  static async [BotCommandName.Uwpc](ctx: TextContext, user: UserDocument) {
-    return TelegrafManager[BotCommandName.UnwatchPriceChange](ctx, user);
   }
 
   static async [BotCommandName.WatchMempoolClear](ctx: TextContext, user: UserDocument) {


### PR DESCRIPTION
No need for short commands. When the command is used without parameters, the user will be requested to enter them in a reply message.
Closes #8 