### PR TITLE
analyze json response on bad status

### DIFF
--- a/packages/server/src/helpers/bitcoin-rpc.ts
+++ b/packages/server/src/helpers/bitcoin-rpc.ts
@@ -208,15 +208,25 @@ async function rpc<T>(properties: RpcProperties): Promise<T> {
       }),
     },
   );
-  if (!response.ok) {
-    throw new Error('Bitcoin rpc response not ok');
+  let responseJson: BitcoinRpcResponse<T>;
+  try {
+    responseJson = (await response.json()) as BitcoinRpcResponse<T>;
+  } catch (error) {
+    if (!response.ok) {
+      // ignore the analysis error
+      throw new Error('Bitcoin rpc failed to parse json and response not ok');
+    }
+    throw error;
   }
-  const responseJson = (await response.json()) as BitcoinRpcResponse<T>;
   if (responseJson.id !== rpcId) {
     throw new Error('Unexpected bitcoin rpc response id');
   }
   if (responseJson.error) {
+    // It is strange that the status is ok but we have an error defined
     throw new BitcoinRpcError(responseJson.error);
+  }
+  if (!response.ok) {
+    throw new Error('Bitcoin rpc response not ok');
   }
   return responseJson.result;
 }
@@ -237,13 +247,24 @@ async function rpcBatch<T>(propertiesArray: RpcProperties[]): Promise<(BitcoinRp
       ),
     },
   );
-  if (!response.ok) {
-    throw new Error('Bitcoin rpc response not ok');
+  let responseJson: BitcoinRpcResponse<T>[];
+  try {
+    responseJson = (await response.json()) as BitcoinRpcResponse<T>[];
+    if (!Array.isArray(responseJson)) {
+      throw new Error('Bitcoin rpc batch response is not array');
+    }
+  } catch (error) {
+    if (!response.ok) {
+      // ignore the analysis error
+      throw new Error('Bitcoin rpc batch failed to parse json and response not ok');
+    }
+    throw error;
   }
-  const responseJson = (await response.json()) as BitcoinRpcResponse<T>[];
   if (responseJson.some(({ id }, index) => `${rpcId}:${index}` !== id)) {
-    throw new Error('Unexpected bitcoin rpc response id');
+    throw new Error('Unexpected bitcoin rpc batch response id');
   }
+  // ignore status code check - not sure what it should be if some of the responses
+  // have errors and some don't.
   return responseJson.map((rpcResponse) => (
     rpcResponse.error ? new BitcoinRpcError(rpcResponse.error) : rpcResponse.result
   ));


### PR DESCRIPTION
Even if the rpc response has a non-ok
status, analyze the json body.

This is important to catch not-found
errors.